### PR TITLE
update minFxVersion

### DIFF
--- a/nd-main.yaml
+++ b/nd-main.yaml
@@ -1,6 +1,6 @@
 $engine: 3
 $onesync: on
-$minFxVersion: 7290
+$minFxVersion: 12913
 name: ND_Core Main
 description: The official recipe for ND_Core.
 author: Andyyy


### PR DESCRIPTION
oxmysql v2.13.0 has just been released and has updated its server dependency. the minimum requirement is now artifact 12913, so i have changed `minFxVersion` to match that so everything can continue to stay on the latest versions